### PR TITLE
test: add phase 1 CLI coverage

### DIFF
--- a/internal/cli/invoice_test.go
+++ b/internal/cli/invoice_test.go
@@ -1,0 +1,407 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	fa "github.com/damacus/freeagent-cli/internal/freeagentapi"
+)
+
+func TestInvoiceCommand_Subcommands(t *testing.T) {
+	cmd := invoiceCommand()
+	if cmd == nil {
+		t.Fatal("invoiceCommand() returned nil")
+	}
+
+	want := map[string]bool{
+		"list":   false,
+		"get":    false,
+		"delete": false,
+		"create": false,
+		"send":   false,
+	}
+
+	for _, sub := range cmd.Subcommands {
+		if _, ok := want[sub.Name]; ok {
+			want[sub.Name] = true
+		}
+	}
+
+	for name, found := range want {
+		if !found {
+			t.Errorf("subcommand %q not found", name)
+		}
+	}
+}
+
+func TestInvoiceCreate_ResolvesContactAndBuildsPayload(t *testing.T) {
+	today := time.Now().Format("2006-01-02")
+
+	dir := t.TempDir()
+	linesPath := filepath.Join(dir, "lines.json")
+	if err := os.WriteFile(linesPath, []byte(`[{"description":"Consulting","quantity":"2","price":"100.00"}]`), 0o600); err != nil {
+		t.Fatalf("write lines file: %v", err)
+	}
+
+	var gotPayload map[string]any
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/contacts":
+			_ = json.NewEncoder(w).Encode(fa.ContactsResponse{
+				Contacts: []fa.Contact{
+					{
+						URL:              srv.URL + "/v2/contacts/1",
+						OrganisationName: "Acme Ltd",
+					},
+				},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/invoices":
+			if err := json.NewDecoder(r.Body).Decode(&gotPayload); err != nil {
+				t.Fatalf("decode invoice payload: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(fa.InvoiceResponse{
+				Invoice: fa.Invoice{
+					URL:       srv.URL + "/v2/invoices/1",
+					Reference: "INV-001",
+				},
+			})
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	out, err := runCLIWithIO(t, testApp(srv.URL), cliArgsWithConfig(t,
+		"invoices", "create",
+		"--contact", "Acme Ltd",
+		"--reference", "INV-001",
+		"--currency", "GBP",
+		"--lines", linesPath,
+	), "")
+	if err != nil {
+		t.Fatalf("invoice create failed: %v", err)
+	}
+
+	invoice, ok := gotPayload["invoice"].(map[string]any)
+	if !ok {
+		t.Fatalf("invoice payload missing or wrong type: %#v", gotPayload["invoice"])
+	}
+	if got := invoice["contact"]; got != srv.URL+"/v2/contacts/1" {
+		t.Errorf("contact: got %v, want %q", got, srv.URL+"/v2/contacts/1")
+	}
+	if got := invoice["reference"]; got != "INV-001" {
+		t.Errorf("reference: got %v, want %q", got, "INV-001")
+	}
+	if got := invoice["currency"]; got != "GBP" {
+		t.Errorf("currency: got %v, want %q", got, "GBP")
+	}
+	if got := invoice["dated_on"]; got != today {
+		t.Errorf("dated_on: got %v, want %q", got, today)
+	}
+	if got := invoice["payment_terms_in_days"]; got != float64(30) {
+		t.Errorf("payment_terms_in_days: got %v, want %v", got, 30)
+	}
+	items, ok := invoice["invoice_items"].([]any)
+	if !ok || len(items) != 1 {
+		t.Fatalf("invoice_items: got %#v, want 1 item", invoice["invoice_items"])
+	}
+
+	if !strings.Contains(out, "Created invoice INV-001 (") {
+		t.Fatalf("unexpected stdout: %q", out)
+	}
+}
+
+func TestInvoiceCreate_UsesBodyFileAndObjectLines(t *testing.T) {
+	dir := t.TempDir()
+
+	bodyPath := filepath.Join(dir, "invoice.json")
+	if err := os.WriteFile(bodyPath, []byte(`{"contact":"https://example.test/v2/contacts/1","reference":"BODY-001","dated_on":"2024-01-15"}`), 0o600); err != nil {
+		t.Fatalf("write body file: %v", err)
+	}
+
+	linesPath := filepath.Join(dir, "lines.json")
+	if err := os.WriteFile(linesPath, []byte(`{"invoice_items":[{"description":"Consulting","quantity":"1","price":"250.00"}]}`), 0o600); err != nil {
+		t.Fatalf("write lines file: %v", err)
+	}
+
+	var gotPayload map[string]any
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/invoices" {
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotPayload); err != nil {
+			t.Fatalf("decode invoice payload: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(fa.InvoiceResponse{
+			Invoice: fa.Invoice{
+				URL:       srv.URL + "/v2/invoices/2",
+				Reference: "BODY-001",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	out, err := runCLIWithIO(t, testApp(srv.URL), cliArgsWithConfig(t,
+		"invoices", "create",
+		"--body", bodyPath,
+		"--lines", linesPath,
+	), "")
+	if err != nil {
+		t.Fatalf("invoice create with body failed: %v", err)
+	}
+
+	invoice, ok := gotPayload["invoice"].(map[string]any)
+	if !ok {
+		t.Fatalf("invoice payload missing or wrong type: %#v", gotPayload["invoice"])
+	}
+	if got := invoice["contact"]; got != "https://example.test/v2/contacts/1" {
+		t.Errorf("contact: got %v, want %q", got, "https://example.test/v2/contacts/1")
+	}
+	if got := invoice["reference"]; got != "BODY-001" {
+		t.Errorf("reference: got %v, want %q", got, "BODY-001")
+	}
+	if got := invoice["dated_on"]; got != "2024-01-15" {
+		t.Errorf("dated_on: got %v, want %q", got, "2024-01-15")
+	}
+	if got := invoice["payment_terms_in_days"]; got != float64(30) {
+		t.Errorf("payment_terms_in_days: got %v, want %v", got, 30)
+	}
+	items, ok := invoice["invoice_items"].([]any)
+	if !ok || len(items) != 1 {
+		t.Fatalf("invoice_items: got %#v, want 1 item", invoice["invoice_items"])
+	}
+
+	if !strings.Contains(out, "Created invoice BODY-001 (") {
+		t.Fatalf("unexpected stdout: %q", out)
+	}
+}
+
+func TestInvoiceCreate_RequiresContact(t *testing.T) {
+	_, err := runCLIWithIO(t, testApp("http://example.test"), cliArgsWithConfig(t, "invoices", "create"), "")
+	if err == nil || !strings.Contains(err.Error(), "contact is required") {
+		t.Fatalf("expected contact validation error, got %v", err)
+	}
+}
+
+func TestInvoiceList_FormatsOutputAndResolvesContactFilter(t *testing.T) {
+	var gotQuery map[string][]string
+	var contactFetches int
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/contacts/1":
+			contactFetches++
+			_ = json.NewEncoder(w).Encode(fa.ContactResponse{
+				Contact: fa.Contact{
+					URL:              srv.URL + "/v2/contacts/1",
+					OrganisationName: "Acme Ltd",
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/invoices":
+			gotQuery = r.URL.Query()
+			_ = json.NewEncoder(w).Encode(fa.InvoicesResponse{
+				Invoices: []fa.Invoice{
+					{
+						URL:        srv.URL + "/v2/invoices/1",
+						Contact:    srv.URL + "/v2/contacts/1",
+						Reference:  "INV-001",
+						Status:     "Open",
+						Currency:   "GBP",
+						TotalValue: "100.00",
+					},
+				},
+			})
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	out, err := runCLIWithIO(t, testApp(srv.URL), cliArgsWithConfig(t,
+		"invoices", "list",
+		"--view", "recent",
+		"--contact", "1",
+		"--from", "2024-01-01",
+		"--to", "2024-01-31",
+		"--status", "Open",
+		"--updated-since", "2024-02-01",
+	), "")
+	if err != nil {
+		t.Fatalf("invoice list failed: %v", err)
+	}
+
+	get := func(key string) string {
+		if values := gotQuery[key]; len(values) > 0 {
+			return values[0]
+		}
+		return ""
+	}
+
+	if got := get("view"); got != "recent" {
+		t.Errorf("view: got %q, want %q", got, "recent")
+	}
+	if got := get("contact"); got != srv.URL+"/v2/contacts/1" {
+		t.Errorf("contact: got %q, want %q", got, srv.URL+"/v2/contacts/1")
+	}
+	if got := get("from_date"); got != "2024-01-01" {
+		t.Errorf("from_date: got %q, want %q", got, "2024-01-01")
+	}
+	if got := get("to_date"); got != "2024-01-31" {
+		t.Errorf("to_date: got %q, want %q", got, "2024-01-31")
+	}
+	if got := get("status"); got != "Open" {
+		t.Errorf("status: got %q, want %q", got, "Open")
+	}
+	if got := get("updated_since"); got != "2024-02-01" {
+		t.Errorf("updated_since: got %q, want %q", got, "2024-02-01")
+	}
+	if contactFetches != 1 {
+		t.Errorf("expected 1 contact fetch, got %d", contactFetches)
+	}
+	if !strings.Contains(out, "Acme Ltd") {
+		t.Fatalf("expected resolved contact name in output, got %q", out)
+	}
+}
+
+func TestInvoiceGet_JSONOutput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/invoices/1" {
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"invoice":{"url":"https://example.test/v2/invoices/1","reference":"INV-001","status":"Open"}}`))
+	}))
+	defer srv.Close()
+
+	out, err := runCLIWithIO(t, testApp(srv.URL), cliArgsWithConfig(t, "--json", "invoices", "get", "--id", "1"), "")
+	if err != nil {
+		t.Fatalf("invoice get failed: %v", err)
+	}
+
+	if got := strings.TrimSpace(out); got != `{"invoice":{"url":"https://example.test/v2/invoices/1","reference":"INV-001","status":"Open"}}` {
+		t.Fatalf("unexpected json output: %q", out)
+	}
+}
+
+func TestInvoiceGet_RequiresIDOrURL(t *testing.T) {
+	_, err := runCLIWithIO(t, testApp("http://example.test"), cliArgsWithConfig(t, "invoices", "get"), "")
+	if err == nil || !strings.Contains(err.Error(), "id or url required") {
+		t.Fatalf("expected id/url validation error, got %v", err)
+	}
+}
+
+func TestInvoiceDelete_DeletesDraftInvoice(t *testing.T) {
+	var deleted bool
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/invoices/1":
+			_ = json.NewEncoder(w).Encode(fa.InvoiceResponse{
+				Invoice: fa.Invoice{
+					URL:       srv.URL + "/v2/invoices/1",
+					Reference: "INV-001",
+					Status:    "Draft",
+				},
+			})
+		case r.Method == http.MethodDelete && r.URL.Path == "/invoices/1":
+			deleted = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	out, err := runCLIWithIO(t, testApp(srv.URL), cliArgsWithConfig(t, "invoices", "delete", "--id", "1", "--yes"), "")
+	if err != nil {
+		t.Fatalf("invoice delete failed: %v", err)
+	}
+	if !deleted {
+		t.Fatal("expected DELETE request to be issued")
+	}
+	if !strings.Contains(out, "Deleted invoice INV-001") {
+		t.Fatalf("unexpected stdout: %q", out)
+	}
+}
+
+func TestInvoiceDelete_RequiresIDOrURL(t *testing.T) {
+	_, err := runCLIWithIO(t, testApp("http://example.test"), cliArgsWithConfig(t, "invoices", "delete"), "")
+	if err == nil || !strings.Contains(err.Error(), "id or url required") {
+		t.Fatalf("expected id/url validation error, got %v", err)
+	}
+}
+
+func TestInvoiceSend_WithBodyFile(t *testing.T) {
+	dir := t.TempDir()
+	bodyPath := filepath.Join(dir, "send.json")
+	if err := os.WriteFile(bodyPath, []byte(`{"invoice":{"email":{"to":"to@example.com","cc":"cc@example.com","bcc":"bcc@example.com","subject":"Subject","body":"Hello"}}}`), 0o600); err != nil {
+		t.Fatalf("write send body: %v", err)
+	}
+
+	var gotPayload map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/invoices/1/send_email" {
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotPayload); err != nil {
+			t.Fatalf("decode send payload: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer srv.Close()
+
+	out, err := runCLIWithIO(t, testApp(srv.URL), cliArgsWithConfig(t, "invoices", "send", "--id", "1", "--body", bodyPath), "")
+	if err != nil {
+		t.Fatalf("invoice send failed: %v", err)
+	}
+	invoice, ok := gotPayload["invoice"].(map[string]any)
+	if !ok {
+		t.Fatalf("invoice payload missing or wrong type: %#v", gotPayload["invoice"])
+	}
+	email, ok := invoice["email"].(map[string]any)
+	if !ok {
+		t.Fatalf("email payload missing or wrong type: %#v", invoice["email"])
+	}
+	if got := email["to"]; got != "to@example.com" {
+		t.Errorf("to: got %v, want %q", got, "to@example.com")
+	}
+	if got := email["subject"]; got != "Subject" {
+		t.Errorf("subject: got %v, want %q", got, "Subject")
+	}
+	if !strings.Contains(out, "Sent invoice") {
+		t.Fatalf("unexpected stdout: %q", out)
+	}
+}
+
+func TestInvoiceSend_MarksAsSent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/invoices/1/transitions/mark_as_sent" {
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer srv.Close()
+
+	out, err := runCLIWithIO(t, testApp(srv.URL), cliArgsWithConfig(t, "invoices", "send", "--id", "1"), "")
+	if err != nil {
+		t.Fatalf("invoice mark-as-sent failed: %v", err)
+	}
+	if !strings.Contains(out, "Marked invoice as sent") {
+		t.Fatalf("unexpected stdout: %q", out)
+	}
+}
+
+func TestInvoiceSend_RequiresIDOrURL(t *testing.T) {
+	_, err := runCLIWithIO(t, testApp("http://example.test"), cliArgsWithConfig(t, "invoices", "send"), "")
+	if err == nil || !strings.Contains(err.Error(), "id or url required") {
+		t.Fatalf("expected id/url validation error, got %v", err)
+	}
+}

--- a/internal/cli/projects_test.go
+++ b/internal/cli/projects_test.go
@@ -1,0 +1,246 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	fa "github.com/damacus/freeagent-cli/internal/freeagentapi"
+)
+
+func TestProjectsCommand_Subcommands(t *testing.T) {
+	cmd := projectsCommand()
+	if cmd == nil {
+		t.Fatal("projectsCommand() returned nil")
+	}
+
+	want := map[string]bool{
+		"list":   false,
+		"get":    false,
+		"create": false,
+		"update": false,
+	}
+
+	for _, sub := range cmd.Subcommands {
+		if _, ok := want[sub.Name]; ok {
+			want[sub.Name] = true
+		}
+	}
+
+	for name, found := range want {
+		if !found {
+			t.Errorf("subcommand %q not found", name)
+		}
+	}
+}
+
+func TestProjectsList_FormatsOutputAndResolvesContactFilter(t *testing.T) {
+	var gotQuery map[string][]string
+	var contactLookups int
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/contacts":
+			contactLookups++
+			_ = json.NewEncoder(w).Encode(fa.ContactsResponse{
+				Contacts: []fa.Contact{
+					{
+						URL:              srv.URL + "/v2/contacts/1",
+						OrganisationName: "Acme Ltd",
+					},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/projects":
+			gotQuery = r.URL.Query()
+			_ = json.NewEncoder(w).Encode(fa.ProjectsResponse{
+				Projects: []fa.Project{
+					{
+						URL:         srv.URL + "/v2/projects/1",
+						Name:        "Website Build",
+						ContactName: "Acme Ltd",
+						Status:      "active",
+					},
+				},
+			})
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	out, err := runCLIWithIO(t, testApp(srv.URL), cliArgsWithConfig(t,
+		"projects", "list",
+		"--contact", "Acme Ltd",
+		"--status", "Active",
+		"--updated-since", "2024-02-01",
+	), "")
+	if err != nil {
+		t.Fatalf("projects list failed: %v", err)
+	}
+
+	get := func(key string) string {
+		if values := gotQuery[key]; len(values) > 0 {
+			return values[0]
+		}
+		return ""
+	}
+
+	if got := get("contact"); got != srv.URL+"/v2/contacts/1" {
+		t.Errorf("contact: got %q, want %q", got, srv.URL+"/v2/contacts/1")
+	}
+	if got := get("view"); got != "active" {
+		t.Errorf("view: got %q, want %q", got, "active")
+	}
+	if got := get("updated_since"); got != "2024-02-01" {
+		t.Errorf("updated_since: got %q, want %q", got, "2024-02-01")
+	}
+	if contactLookups != 1 {
+		t.Errorf("expected 1 contact lookup, got %d", contactLookups)
+	}
+	if !strings.Contains(out, "Website Build") || !strings.Contains(out, "Acme Ltd") {
+		t.Fatalf("unexpected stdout: %q", out)
+	}
+}
+
+func TestProjectsGet_JSONOutput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v2/projects/1" {
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"project":{"url":"https://example.test/v2/projects/1","name":"Website Build","status":"active"}}`))
+	}))
+	defer srv.Close()
+
+	out, err := runCLIWithIO(t, testApp(srv.URL), cliArgsWithConfig(t, "--json", "projects", "get", "1"), "")
+	if err != nil {
+		t.Fatalf("projects get failed: %v", err)
+	}
+	if got := strings.TrimSpace(out); got != `{"project":{"url":"https://example.test/v2/projects/1","name":"Website Build","status":"active"}}` {
+		t.Fatalf("unexpected json output: %q", out)
+	}
+}
+
+func TestProjectsGet_RequiresIDOrURL(t *testing.T) {
+	_, err := runCLIWithIO(t, testApp("http://example.test"), cliArgsWithConfig(t, "projects", "get"), "")
+	if err == nil || !strings.Contains(err.Error(), "project id or url required") {
+		t.Fatalf("expected id/url validation error, got %v", err)
+	}
+}
+
+func TestProjectsCreate_ResolvesContactAndSerializesFlags(t *testing.T) {
+	var gotPayload map[string]any
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/projects":
+			if err := json.NewDecoder(r.Body).Decode(&gotPayload); err != nil {
+				t.Fatalf("decode project payload: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(fa.ProjectResponse{
+				Project: fa.Project{
+					URL:  srv.URL + "/v2/projects/1",
+					Name: "Website Build",
+				},
+			})
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	out, err := runCLIWithIO(t, testApp(srv.URL), cliArgsWithConfig(t,
+		"projects", "create",
+		"--name", "Website Build",
+		"--contact", "1",
+		"--currency", "eur",
+		"--status", "Active",
+		"--starts-on", "2024-01-01",
+		"--ends-on", "2024-12-31",
+		"--billing-rate", "150.00",
+		"--billing-period", "hour",
+		"--is-ir35",
+	), "")
+	if err != nil {
+		t.Fatalf("projects create failed: %v", err)
+	}
+
+	project, ok := gotPayload["project"].(map[string]any)
+	if !ok {
+		t.Fatalf("project payload missing or wrong type: %#v", gotPayload["project"])
+	}
+	if got := project["name"]; got != "Website Build" {
+		t.Errorf("name: got %v, want %q", got, "Website Build")
+	}
+	if got := project["contact"]; got != srv.URL+"/v2/contacts/1" {
+		t.Errorf("contact: got %v, want %q", got, srv.URL+"/v2/contacts/1")
+	}
+	if got := project["currency"]; got != "EUR" {
+		t.Errorf("currency: got %v, want %q", got, "EUR")
+	}
+	if got := project["status"]; got != "Active" {
+		t.Errorf("status: got %v, want %q", got, "Active")
+	}
+	if got := project["starts_on"]; got != "2024-01-01" {
+		t.Errorf("starts_on: got %v, want %q", got, "2024-01-01")
+	}
+	if got := project["ends_on"]; got != "2024-12-31" {
+		t.Errorf("ends_on: got %v, want %q", got, "2024-12-31")
+	}
+	if got := project["normal_billing_rate"]; got != "150.00" {
+		t.Errorf("normal_billing_rate: got %v, want %q", got, "150.00")
+	}
+	if got := project["billing_period"]; got != "hour" {
+		t.Errorf("billing_period: got %v, want %q", got, "hour")
+	}
+	if got := project["is_ir35"]; got != true {
+		t.Errorf("is_ir35: got %v, want %v", got, true)
+	}
+	if !strings.Contains(out, "Created project Website Build (") {
+		t.Fatalf("unexpected stdout: %q", out)
+	}
+}
+
+func TestProjectsUpdate_SerializesBoolFalse(t *testing.T) {
+	var gotPayload map[string]any
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/v2/projects/1" {
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotPayload); err != nil {
+			t.Fatalf("decode project payload: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"project":{"url":"https://example.test/v2/projects/1","name":"Website Build"}}`))
+	}))
+	defer srv.Close()
+
+	if _, err := runCLIWithIO(t, testApp(srv.URL), cliArgsWithConfig(t,
+		"projects", "update",
+		"--status", "Completed",
+		"--is-ir35",
+		"1",
+	), ""); err != nil {
+		t.Fatalf("projects update failed: %v", err)
+	}
+
+	project, ok := gotPayload["project"].(map[string]any)
+	if !ok {
+		t.Fatalf("project payload missing or wrong type: %#v", gotPayload["project"])
+	}
+	if got := project["is_ir35"]; got != true {
+		t.Errorf("is_ir35: got %v, want %v", got, true)
+	}
+	if got := project["status"]; got != "Completed" {
+		t.Errorf("status: got %v, want %q", got, "Completed")
+	}
+}
+
+func TestProjectsUpdate_RequiresFields(t *testing.T) {
+	_, err := runCLIWithIO(t, testApp("http://example.test"), cliArgsWithConfig(t, "projects", "update", "1"), "")
+	if err == nil || !strings.Contains(err.Error(), "no fields to update") {
+		t.Fatalf("expected empty update validation error, got %v", err)
+	}
+}

--- a/internal/cli/raw_test.go
+++ b/internal/cli/raw_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRawCommand_RequiresPath(t *testing.T) {
+	_, err := runCLIWithIO(t, testApp("http://example.test"), cliArgsWithConfig(t, "raw"), "")
+	if err == nil || !strings.Contains(err.Error(), "path is required") {
+		t.Fatalf("expected path validation error, got %v", err)
+	}
+}
+
+func TestRawAction_BodyFileAndPrettyPrintsJSON(t *testing.T) {
+	dir := t.TempDir()
+	bodyPath := filepath.Join(dir, "body.json")
+	if err := os.WriteFile(bodyPath, []byte(`{"hello":"world"}`), 0o600); err != nil {
+		t.Fatalf("write body file: %v", err)
+	}
+
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v2/custom" {
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		gotBody = string(data)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	out, err := runCLIWithIO(t, testApp(srv.URL), cliArgsWithConfig(t,
+		"raw",
+		"--method", "POST",
+		"--path", "/v2/custom",
+		"--body", bodyPath,
+	), "")
+	if err != nil {
+		t.Fatalf("raw action failed: %v", err)
+	}
+
+	if gotBody != `{"hello":"world"}` {
+		t.Fatalf("unexpected request body: %q", gotBody)
+	}
+	if got := strings.TrimSpace(out); got != "{\n  \"ok\": true\n}" {
+		t.Fatalf("unexpected pretty-printed output: %q", out)
+	}
+}
+
+func TestRawAction_WritesPlainTextResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v2/plain" {
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		_, _ = w.Write([]byte("plain response"))
+	}))
+	defer srv.Close()
+
+	out, err := runCLIWithIO(t, testApp(srv.URL), cliArgsWithConfig(t,
+		"raw",
+		"--path", "/v2/plain",
+	), "")
+	if err != nil {
+		t.Fatalf("raw action failed: %v", err)
+	}
+
+	if got := strings.TrimSpace(out); got != "plain response" {
+		t.Fatalf("unexpected plaintext output: %q", out)
+	}
+}

--- a/internal/cli/testhelpers_test.go
+++ b/internal/cli/testhelpers_test.go
@@ -50,6 +50,7 @@ func testApp(baseURL string) *cli.App {
 	app := NewApp("test")
 
 	origBefore := app.Before
+	origNewClientFn := newClientFn
 	app.Before = func(c *cli.Context) error {
 		// Run the original initRuntime first.
 		if err := origBefore(c); err != nil {
@@ -73,6 +74,10 @@ func testApp(baseURL string) *cli.App {
 			}
 			return client, nil, nil
 		}
+		return nil
+	}
+	app.After = func(*cli.Context) error {
+		newClientFn = origNewClientFn
 		return nil
 	}
 	return app

--- a/internal/cli/testio_test.go
+++ b/internal/cli/testio_test.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func runCLIWithIO(t *testing.T, app interface{ Run([]string) error }, args []string, stdin string) (string, error) {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	oldStdin := os.Stdin
+
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+	defer stdoutR.Close()
+
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdin pipe: %v", err)
+	}
+	defer stdinR.Close()
+
+	if _, err := io.WriteString(stdinW, stdin); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+	if err := stdinW.Close(); err != nil {
+		t.Fatalf("close stdin writer: %v", err)
+	}
+
+	os.Stdout = stdoutW
+	os.Stdin = stdinR
+
+	var out bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(&out, stdoutR)
+		close(done)
+	}()
+
+	runErr := app.Run(args)
+
+	if err := stdoutW.Close(); err != nil {
+		t.Fatalf("close stdout writer: %v", err)
+	}
+
+	os.Stdout = oldStdout
+	os.Stdin = oldStdin
+
+	<-done
+	return out.String(), runErr
+}
+
+func cliArgsWithConfig(t *testing.T, args ...string) []string {
+	t.Helper()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.json")
+	return append([]string{"fa", "--config", cfgPath}, args...)
+}


### PR DESCRIPTION
Phase 1 of the missing-test plan.

- Adds focused coverage for invoices, projects, and raw API requests.
- Adds an IO helper for CLI tests and restores the client factory after each run.
- Verifies payload construction, query translation, JSON output mode, and required-argument validation.

Validation:
- go test ./...
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/freeagent-cli/pull/11" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
