### PR TITLE
feat: add version command and contacts update subcommand

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -79,6 +79,7 @@ func NewApp(version string) *cli.App {
 			tasksCommand(),
 			timeslipsCommand(),
 			usersCommand(),
+			versionCommand(),
 			completionCommand(),
 		},
 	}

--- a/internal/cli/contacts.go
+++ b/internal/cli/contacts.go
@@ -75,6 +75,29 @@ func contactsCommand() *cli.Command {
 				},
 				Action: contactsCreate,
 			},
+			{
+				Name:      "update",
+				Usage:     "Update a contact",
+				ArgsUsage: "<id|url>",
+				Flags: []cli.Flag{
+					&cli.StringFlag{Name: "body", Usage: "JSON file with full contact payload or contact object"},
+					&cli.StringFlag{Name: "organisation", Usage: "Organisation name"},
+					&cli.StringFlag{Name: "first-name"},
+					&cli.StringFlag{Name: "last-name"},
+					&cli.StringFlag{Name: "email"},
+					&cli.StringFlag{Name: "billing-email"},
+					&cli.StringFlag{Name: "phone"},
+					&cli.StringFlag{Name: "mobile"},
+					&cli.StringFlag{Name: "address1"},
+					&cli.StringFlag{Name: "address2"},
+					&cli.StringFlag{Name: "address3"},
+					&cli.StringFlag{Name: "town"},
+					&cli.StringFlag{Name: "region"},
+					&cli.StringFlag{Name: "postcode"},
+					&cli.StringFlag{Name: "country"},
+				},
+				Action: contactsUpdate,
+			},
 		},
 	}
 }
@@ -250,7 +273,7 @@ func contactsCreate(c *cli.Context) error {
 		return err
 	}
 
-	input, err := buildContactInput(c)
+	input, err := buildContactInput(c, true)
 	if err != nil {
 		return err
 	}
@@ -277,7 +300,48 @@ func contactsCreate(c *cli.Context) error {
 	return nil
 }
 
-func buildContactInput(c *cli.Context) (fa.ContactInput, error) {
+func contactsUpdate(c *cli.Context) error {
+	rt, err := runtimeFrom(c)
+	if err != nil {
+		return err
+	}
+
+	cfg, _, err := loadConfig(rt)
+	if err != nil {
+		return err
+	}
+	profile := ensureProfile(cfg, rt.Profile, rt, config.Profile{})
+
+	client, _, err := newClient(c.Context, rt, profile)
+	if err != nil {
+		return err
+	}
+
+	id := strings.TrimSpace(c.Args().First())
+	if id == "" {
+		return fmt.Errorf("contact id or url required")
+	}
+	contactURL, err := normalizeResourceURL(profile.BaseURL, "contacts", id)
+	if err != nil {
+		return err
+	}
+
+	input, err := buildContactInput(c, false)
+	if err != nil {
+		return err
+	}
+	if contactInputEmpty(input) {
+		return fmt.Errorf("no fields to update")
+	}
+
+	resp, _, _, err := client.DoJSON(c.Context, http.MethodPut, contactURL, fa.UpdateContactRequest{Contact: input})
+	if err != nil {
+		return err
+	}
+	return writeJSONOutput(resp)
+}
+
+func buildContactInput(c *cli.Context, requireIdentity bool) (fa.ContactInput, error) {
 	input := fa.ContactInput{}
 
 	if bodyPath := c.String("body"); bodyPath != "" {
@@ -348,10 +412,27 @@ func buildContactInput(c *cli.Context) (fa.ContactInput, error) {
 		input.Country = country
 	}
 
-	if input.OrganisationName == "" && strings.TrimSpace(input.FirstName) == "" && strings.TrimSpace(input.LastName) == "" {
+	if requireIdentity && input.OrganisationName == "" && strings.TrimSpace(input.FirstName) == "" && strings.TrimSpace(input.LastName) == "" {
 		return input, fmt.Errorf("organisation or first-name/last-name required (or include in --body)")
 	}
 	return input, nil
+}
+
+func contactInputEmpty(input fa.ContactInput) bool {
+	return input.OrganisationName == "" &&
+		input.FirstName == "" &&
+		input.LastName == "" &&
+		input.Email == "" &&
+		input.BillingEmail == "" &&
+		input.PhoneNumber == "" &&
+		input.Mobile == "" &&
+		input.Address1 == "" &&
+		input.Address2 == "" &&
+		input.Address3 == "" &&
+		input.Town == "" &&
+		input.Region == "" &&
+		input.Postcode == "" &&
+		input.Country == ""
 }
 
 func resolveContactValue(ctx context.Context, client *freeagent.Client, baseURL, value string) (string, error) {

--- a/internal/cli/contacts_test.go
+++ b/internal/cli/contacts_test.go
@@ -150,6 +150,7 @@ func TestContactsCommand_Subcommands(t *testing.T) {
 		"search": false,
 		"get":    false,
 		"create": false,
+		"update": false,
 	}
 
 	for _, sub := range cmd.Subcommands {
@@ -247,5 +248,55 @@ func TestContactsCreateJSON(t *testing.T) {
 	}
 	if !strings.Contains(out, "New Corp") {
 		t.Errorf("expected org name in output, got: %s", out)
+	}
+}
+
+func TestContactsUpdate(t *testing.T) {
+	var gotPayload map[string]any
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/v2/contacts/1" {
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotPayload); err != nil {
+			t.Fatalf("decode contact payload: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"contact":{"url":"https://example.test/v2/contacts/1","organisation_name":"Equal Experts UK Ltd"}}`))
+	}))
+	defer srv.Close()
+
+	if _, err := runCLIWithIO(t, testApp(srv.URL), cliArgsWithConfig(t,
+		"contacts", "update",
+		"--organisation", "Equal Experts UK Ltd",
+		"--address1", "17 Britton Street",
+		"--town", "London",
+		"--postcode", "EC1M 5NZ",
+		"1",
+	), ""); err != nil {
+		t.Fatalf("contacts update failed: %v", err)
+	}
+
+	contact, ok := gotPayload["contact"].(map[string]any)
+	if !ok {
+		t.Fatalf("contact payload missing or wrong type: %#v", gotPayload["contact"])
+	}
+	if got := contact["organisation_name"]; got != "Equal Experts UK Ltd" {
+		t.Errorf("organisation_name: got %v, want %q", got, "Equal Experts UK Ltd")
+	}
+	if got := contact["address1"]; got != "17 Britton Street" {
+		t.Errorf("address1: got %v, want %q", got, "17 Britton Street")
+	}
+	if got := contact["town"]; got != "London" {
+		t.Errorf("town: got %v, want %q", got, "London")
+	}
+	if got := contact["postcode"]; got != "EC1M 5NZ" {
+		t.Errorf("postcode: got %v, want %q", got, "EC1M 5NZ")
+	}
+}
+
+func TestContactsUpdate_RequiresFields(t *testing.T) {
+	_, err := runCLIWithIO(t, testApp("http://example.test"), cliArgsWithConfig(t, "contacts", "update", "1"), "")
+	if err == nil || !strings.Contains(err.Error(), "no fields to update") {
+		t.Fatalf("expected empty update validation error, got %v", err)
 	}
 }

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -1,0 +1,18 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+)
+
+func versionCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "version",
+		Usage: "Print the CLI version",
+		Action: func(c *cli.Context) error {
+			_, err := fmt.Fprintln(c.App.Writer, c.App.Version)
+			return err
+		},
+	}
+}

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -1,0 +1,21 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestVersionCommand_PrintsAppVersion(t *testing.T) {
+	app := NewApp("dev (commit 36d324c7b853)")
+	var stdout bytes.Buffer
+	app.Writer = &stdout
+
+	if err := app.Run([]string{"fa", "version"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got := strings.TrimSpace(stdout.String()); got != "dev (commit 36d324c7b853)" {
+		t.Fatalf("version output = %q, want %q", got, "dev (commit 36d324c7b853)")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,15 +3,57 @@ package main
 import (
 	"log"
 	"os"
+	"runtime/debug"
+	"strings"
 
 	"github.com/damacus/freeagent-cli/internal/cli"
 )
 
 // version is set at build time via ldflags.
 var version = "dev"
+var commit = ""
+var date = ""
+
+func buildVersion() string {
+	if version != "dev" {
+		return version
+	}
+
+	revision := commit
+	dirty := false
+
+	if revision == "" {
+		if info, ok := debug.ReadBuildInfo(); ok {
+			for _, setting := range info.Settings {
+				switch setting.Key {
+				case "vcs.revision":
+					if revision == "" {
+						revision = setting.Value
+					}
+				case "vcs.modified":
+					dirty = setting.Value == "true"
+				}
+			}
+		}
+	}
+
+	if revision == "" {
+		return version
+	}
+
+	if len(revision) > 12 {
+		revision = revision[:12]
+	}
+
+	if dirty {
+		return "dev (commit " + revision + ", dirty)"
+	}
+
+	return "dev (commit " + strings.TrimSpace(revision) + ")"
+}
 
 func main() {
-	app := cli.NewApp(version)
+	app := cli.NewApp(buildVersion())
 	if err := app.Run(os.Args); err != nil {
 		log.Fatal(err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,33 @@
+package main
+
+import "testing"
+
+func TestBuildVersion_ReleaseBuild(t *testing.T) {
+	origVersion, origCommit := version, commit
+	t.Cleanup(func() {
+		version = origVersion
+		commit = origCommit
+	})
+
+	version = "0.4.0"
+	commit = "36d324c7b8533f637683d1afaae52e87a54bc122"
+
+	if got := buildVersion(); got != "0.4.0" {
+		t.Fatalf("buildVersion() = %q, want %q", got, "0.4.0")
+	}
+}
+
+func TestBuildVersion_DevBuildIncludesCommit(t *testing.T) {
+	origVersion, origCommit := version, commit
+	t.Cleanup(func() {
+		version = origVersion
+		commit = origCommit
+	})
+
+	version = "dev"
+	commit = "36d324c7b8533f637683d1afaae52e87a54bc122"
+
+	if got := buildVersion(); got != "dev (commit 36d324c7b853)" {
+		t.Fatalf("buildVersion() = %q, want %q", got, "dev (commit 36d324c7b853)")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `version` command that prints the CLI version
- Add `buildVersion()` to include VCS commit hash in dev builds
- Add `contacts update` subcommand with full field support (organisation, address, email, phone, etc.)

## Test plan

- [ ] `version` command prints expected output
- [ ] `contacts update <id> --organisation "..."` sends PUT request with correct payload
- [ ] `contacts update <id>` with no fields returns validation error
- [ ] All existing tests continue to pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/freeagent-cli/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
