### PR TITLE
fix: list nested marked bank reviews

### DIFF
--- a/internal/cli/bank_review_test.go
+++ b/internal/cli/bank_review_test.go
@@ -25,12 +25,15 @@ func TestBankReviewList_JSON(t *testing.T) {
 			if got := r.URL.Query().Get("bank_account"); got != baseURL+"/bank_accounts/1" {
 				t.Fatalf("bank_account query = %q, want %q", got, baseURL+"/bank_accounts/1")
 			}
+			if got := r.URL.Query().Get("view"); got != "marked_for_review" {
+				t.Fatalf("view query = %q, want marked_for_review", got)
+			}
 			if r.Method != http.MethodGet {
 				t.Fatalf("method = %s, want GET", r.Method)
 			}
 			writeJSON(t, w, fa.BankTransactionsResponse{BankTransactions: []fa.BankTransaction{
-				reviewTransaction(baseURL, "1", "Windsurf", "Windsurf August charge", "-12.34", true, "101"),
-				reviewTransaction(baseURL, "2", "Cloudflare", "Cloudflare DNS", "-8.00", true, "102"),
+				reviewTransaction(baseURL, "1", "Windsurf", "Windsurf August charge", "-12.34", false, "101"),
+				reviewTransaction(baseURL, "2", "Cloudflare", "Cloudflare DNS", "-8.00", false, "102"),
 				reviewTransaction(baseURL, "3", "Unmarked", "Should not appear", "-1.00", false),
 			}})
 		case "/bank_transaction_explanations/101":

--- a/internal/freeagent/bank.go
+++ b/internal/freeagent/bank.go
@@ -182,19 +182,24 @@ func (c *Client) UpdateBankTransactionExplanation(ctx context.Context, explanati
 }
 
 func (c *Client) ListBankReviewItems(ctx context.Context, opts ListBankTransactionsOptions) ([]BankReviewItem, error) {
+	opts.View = "marked_for_review"
 	transactions, err := c.ListBankTransactions(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	var marked []fa.BankTransaction
-	for _, transaction := range transactions {
-		if transaction.MarkedForReview {
-			marked = append(marked, transaction)
-		}
+	items, err := c.BuildBankReviewItems(ctx, transactions)
+	if err != nil {
+		return nil, err
 	}
 
-	return c.BuildBankReviewItems(ctx, marked)
+	marked := make([]BankReviewItem, 0, len(items))
+	for _, item := range items {
+		if item.MarkedForReview {
+			marked = append(marked, item)
+		}
+	}
+	return marked, nil
 }
 
 func (c *Client) GetBankReviewItem(ctx context.Context, transactionURL string) (BankReviewItem, error) {
@@ -228,7 +233,6 @@ func (c *Client) BuildBankReviewItems(ctx context.Context, transactions []fa.Ban
 			Amount:          transaction.Amount,
 			Description:     transaction.Description,
 			FullDescription: transaction.FullDescription,
-			MarkedForReview: transaction.MarkedForReview,
 		}
 
 		for _, ref := range transaction.BankTransactionExplanations {
@@ -255,6 +259,9 @@ func (c *Client) BuildBankReviewItems(ctx context.Context, transactions []fa.Ban
 			}
 			if explanation.Attachment != nil {
 				item.AttachmentFilenames = append(item.AttachmentFilenames, explanation.Attachment.FileName)
+			}
+			if explanation.MarkedForReview {
+				item.MarkedForReview = true
 			}
 		}
 

--- a/internal/freeagent/bank_test.go
+++ b/internal/freeagent/bank_test.go
@@ -318,22 +318,25 @@ func newBankTestClientFromServer(t *testing.T, srv *httptest.Server) *Client {
 
 func TestListBankReviewItems(t *testing.T) {
 	// The handler serves:
-	//   GET /v2/bank_transactions                 -> list with one marked_for_review transaction
-	//   GET /v2/bank_transaction_explanations/99  -> the explanation for that transaction
+	//   GET /v2/bank_transactions                  -> list with nested review state
+	//   GET /v2/bank_transaction_explanations/99   -> marked explanation
+	//   GET /v2/bank_transaction_explanations/100  -> unmarked explanation
 	//
 	// We need srv.URL inside the handler, so we build the server first.
 	var srvURL string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v2/bank_transactions":
+			if got := r.URL.Query().Get("view"); got != "marked_for_review" {
+				t.Fatalf("view query = %q, want marked_for_review", got)
+			}
 			json.NewEncoder(w).Encode(fa.BankTransactionsResponse{ //nolint:errcheck
 				BankTransactions: []fa.BankTransaction{
 					{
-						URL:             srvURL + "/v2/bank_transactions/10",
-						Description:     "Supermarket",
-						Amount:          "-42.00",
-						DatedOn:         "2024-05-01",
-						MarkedForReview: true,
+						URL:         srvURL + "/v2/bank_transactions/10",
+						Description: "Supermarket",
+						Amount:      "-42.00",
+						DatedOn:     "2024-05-01",
 						BankTransactionExplanations: []fa.BankTransactionReference{
 							{URL: srvURL + "/v2/bank_transaction_explanations/99"},
 						},
@@ -341,17 +344,31 @@ func TestListBankReviewItems(t *testing.T) {
 					{
 						URL:             srvURL + "/v2/bank_transactions/11",
 						Description:     "Not reviewed",
-						MarkedForReview: false,
+						MarkedForReview: true,
+						BankTransactionExplanations: []fa.BankTransactionReference{
+							{URL: srvURL + "/v2/bank_transaction_explanations/100"},
+						},
 					},
 				},
 			})
 		case "/v2/bank_transaction_explanations/99":
 			json.NewEncoder(w).Encode(fa.BankTransactionExplanationResponse{ //nolint:errcheck
 				BankTransactionExplanation: fa.BankTransactionExplanation{
-					URL:         srvURL + "/v2/bank_transaction_explanations/99",
-					Description: "Grocery shopping",
-					GrossValue:  "-42.00",
-					Category:    "https://api.freeagent.com/v2/categories/283",
+					URL:             srvURL + "/v2/bank_transaction_explanations/99",
+					Description:     "Grocery shopping",
+					GrossValue:      "-42.00",
+					Category:        "https://api.freeagent.com/v2/categories/283",
+					MarkedForReview: true,
+				},
+			})
+		case "/v2/bank_transaction_explanations/100":
+			json.NewEncoder(w).Encode(fa.BankTransactionExplanationResponse{ //nolint:errcheck
+				BankTransactionExplanation: fa.BankTransactionExplanation{
+					URL:             srvURL + "/v2/bank_transaction_explanations/100",
+					Description:     "Approved purchase",
+					GrossValue:      "-10.00",
+					Category:        "https://api.freeagent.com/v2/categories/283",
+					MarkedForReview: false,
 				},
 			})
 		default:
@@ -381,17 +398,42 @@ func TestListBankReviewItems(t *testing.T) {
 	if !item.MarkedForReview {
 		t.Error("expected MarkedForReview to be true")
 	}
+	if len(item.Explanations) != 1 || !item.Explanations[0].MarkedForReview {
+		t.Fatalf("expected one marked explanation, got %+v", item.Explanations)
+	}
 }
 
 func TestListBankReviewItems_NoMarked(t *testing.T) {
-	client, srv := newBankTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(fa.BankTransactionsResponse{ //nolint:errcheck
-			BankTransactions: []fa.BankTransaction{
-				{URL: "https://api.freeagent.com/v2/bank_transactions/1", MarkedForReview: false},
-			},
-		})
-	})
+	var srvURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/bank_transactions":
+			json.NewEncoder(w).Encode(fa.BankTransactionsResponse{ //nolint:errcheck
+				BankTransactions: []fa.BankTransaction{
+					{
+						URL:             srvURL + "/v2/bank_transactions/1",
+						MarkedForReview: true,
+						BankTransactionExplanations: []fa.BankTransactionReference{
+							{URL: srvURL + "/v2/bank_transaction_explanations/101"},
+						},
+					},
+				},
+			})
+		case "/v2/bank_transaction_explanations/101":
+			json.NewEncoder(w).Encode(fa.BankTransactionExplanationResponse{ //nolint:errcheck
+				BankTransactionExplanation: fa.BankTransactionExplanation{
+					URL:             srvURL + "/v2/bank_transaction_explanations/101",
+					MarkedForReview: false,
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
 	defer srv.Close()
+	srvURL = srv.URL
+
+	client := newBankTestClientFromServer(t, srv)
 
 	items, err := client.ListBankReviewItems(context.Background(), ListBankTransactionsOptions{})
 	if err != nil {


### PR DESCRIPTION
## Summary

- request FreeAgent bank transactions with the `marked_for_review` view
- derive review state from fetched bank transaction explanations instead of the absent top-level field
- filter enriched review items so only transactions with a marked explanation are returned
- add client and CLI regression coverage for the live API response shape

Closes #37

## Verification

- `go test ./internal/freeagent ./internal/cli`
- `go test ./...`
- `go vet ./...`
- live read-only comparison: released CLI returned 0 items; `bank list --view marked_for_review` and the patched binary returned the same 13 transaction IDs