### PR TITLE
fix: default timeslips to current user

### DIFF
--- a/internal/cli/timeslips.go
+++ b/internal/cli/timeslips.go
@@ -186,6 +186,7 @@ func timeslipsGet(c *cli.Command) error {
 }
 
 func timeslipsCreate(c *cli.Command) error {
+	ctx := commandContext(c)
 	rt, err := runtimeFrom(c)
 	if err != nil {
 		return err
@@ -195,7 +196,7 @@ func timeslipsCreate(c *cli.Command) error {
 		return err
 	}
 	profile := ensureProfile(cfg, rt.Profile, rt, config.Profile{})
-	client, _, err := newClient(commandContext(c), rt, profile)
+	client, _, err := newClient(ctx, rt, profile)
 	if err != nil {
 		return err
 	}
@@ -215,18 +216,32 @@ func timeslipsCreate(c *cli.Command) error {
 		DatedOn: c.String("dated-on"),
 		Hours:   c.String("hours"),
 	}
-	if v := c.String("user"); v != "" {
-		userURL, err := normalizeResourceURL(profile.BaseURL, "users", v)
+	if user := c.String("user"); user != "" {
+		userURL, err := normalizeResourceURL(profile.BaseURL, "users", user)
 		if err != nil {
 			return err
 		}
 		input.User = userURL
+	} else {
+		resp, _, _, err := client.Do(ctx, http.MethodGet, "/users/me", nil, "")
+		if err != nil {
+			return fmt.Errorf("get authenticated user: %w", err)
+		}
+
+		var decoded fa.UserResponse
+		if err := json.Unmarshal(resp, &decoded); err != nil {
+			return fmt.Errorf("decode authenticated user: %w", err)
+		}
+		if decoded.User.URL == "" {
+			return fmt.Errorf("authenticated user response did not include a URL; pass --user explicitly")
+		}
+		input.User = decoded.User.URL
 	}
 	if v := c.String("comment"); v != "" {
 		input.Comment = v
 	}
 
-	resp, _, _, err := client.DoJSON(commandContext(c), http.MethodPost, "/timeslips", fa.CreateTimeslipRequest{Timeslip: input})
+	resp, _, _, err := client.DoJSON(ctx, http.MethodPost, "/timeslips", fa.CreateTimeslipRequest{Timeslip: input})
 	if err != nil {
 		return err
 	}

--- a/internal/cli/timeslips_test.go
+++ b/internal/cli/timeslips_test.go
@@ -89,24 +89,52 @@ func TestTimeslipsGetJSON(t *testing.T) {
 	}
 }
 
-func TestTimeslipsCreateJSON(t *testing.T) {
+func TestTimeslipsCreateDefaultsToAuthenticatedUser(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			t.Errorf("expected POST, got %s", r.Method)
-			http.Error(w, "wrong method", http.StatusMethodNotAllowed)
-			return
-		}
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(fa.TimeslipResponse{
-			Timeslip: fa.Timeslip{
-				URL:     "http://x/v2/timeslips/2",
-				DatedOn: "2024-02-01",
-				Hours:   "4.5",
-				Project: "http://x/v2/projects/1",
-				Task:    "http://x/v2/tasks/1",
-			},
-		})
+
+		switch r.URL.Path {
+		case "/v2/users/me":
+			if r.Method != http.MethodGet {
+				t.Errorf("expected GET, got %s", r.Method)
+				http.Error(w, "wrong method", http.StatusMethodNotAllowed)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(fa.UserResponse{
+				User: fa.User{URL: "http://x/v2/users/1"},
+			})
+		case "/v2/timeslips":
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+				http.Error(w, "wrong method", http.StatusMethodNotAllowed)
+				return
+			}
+
+			var request fa.CreateTimeslipRequest
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Errorf("decode request: %v", err)
+				http.Error(w, "invalid request", http.StatusBadRequest)
+				return
+			}
+			if got := request.Timeslip.User; got != "http://x/v2/users/1" {
+				t.Errorf("expected authenticated user URL, got %q", got)
+			}
+
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(fa.TimeslipResponse{
+				Timeslip: fa.Timeslip{
+					URL:     "http://x/v2/timeslips/2",
+					User:    request.Timeslip.User,
+					DatedOn: "2024-02-01",
+					Hours:   "4.5",
+					Project: "http://x/v2/projects/1",
+					Task:    "http://x/v2/tasks/1",
+				},
+			})
+		default:
+			t.Errorf("unexpected request path %q", r.URL.Path)
+			http.NotFound(w, r)
+		}
 	}))
 	defer srv.Close()
 
@@ -122,6 +150,86 @@ func TestTimeslipsCreateJSON(t *testing.T) {
 	}
 	if !strings.Contains(out, "4.5") {
 		t.Errorf("expected hours in output, got: %s", out)
+	}
+}
+
+func TestTimeslipsCreateUsesExplicitUser(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/timeslips" {
+			t.Errorf("unexpected request path %q", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+			http.Error(w, "wrong method", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var request fa.CreateTimeslipRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		if got := request.Timeslip.User; got != srv.URL+"/v2/users/2" {
+			t.Errorf("expected explicit user URL, got %q", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(fa.TimeslipResponse{
+			Timeslip: fa.Timeslip{
+				URL:     srv.URL + "/v2/timeslips/2",
+				User:    request.Timeslip.User,
+				DatedOn: "2024-02-01",
+				Hours:   "4.5",
+				Project: srv.URL + "/v2/projects/1",
+				Task:    srv.URL + "/v2/tasks/1",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	app := testApp(srv.URL + "/v2")
+	_, err := runCLIWithIO(t, app, cliArgsWithConfig(t, "--json", "timeslips", "create",
+		"--project", "1",
+		"--task", "1",
+		"--dated-on", "2024-02-01",
+		"--hours", "4.5",
+		"--user", "2",
+	), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTimeslipsCreateRejectsMissingAuthenticatedUserURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/users/me" {
+			t.Errorf("unexpected request path %q", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(fa.UserResponse{})
+	}))
+	defer srv.Close()
+
+	app := testApp(srv.URL + "/v2")
+	_, err := runCLIWithIO(t, app, cliArgsWithConfig(t, "timeslips", "create",
+		"--project", "1",
+		"--task", "1",
+		"--dated-on", "2024-02-01",
+		"--hours", "4.5",
+	), "")
+	if err == nil {
+		t.Fatal("expected missing authenticated user URL error")
+	}
+	if !strings.Contains(err.Error(), "pass --user explicitly") {
+		t.Fatalf("expected actionable error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- resolve the authenticated user through `/users/me` when `timeslips create --user` is omitted
- include the resolved user URL in the timeslip creation payload
- preserve explicit `--user` behavior and fail locally with actionable guidance if the user URL is missing

Closes #40

## Verification

- `mise exec go@1.26.5 -- go test ./internal/cli -run TestTimeslipsCreate -count=1`
- `mise exec go@1.26.5 -- go test ./... -count=1`
- `mise exec go@1.26.5 -- go vet ./...`
- `mise exec go@1.26.5 -- go build ./...`
- `git diff --check`

## Risks / follow-ups

- creation without `--user` now makes one additional API request to `/users/me`; explicit `--user` remains a single request